### PR TITLE
Update single game to use same expression for keys

### DIFF
--- a/wiki/start/a-simple-game.md
+++ b/wiki/start/a-simple-game.md
@@ -468,7 +468,7 @@ import java.util.Iterator;
 
 import com.badlogic.gdx.ApplicationAdapter;
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.Input.Keys;
+import com.badlogic.gdx.Input;
 import com.badlogic.gdx.audio.Music;
 import com.badlogic.gdx.audio.Sound;
 import com.badlogic.gdx.graphics.OrthographicCamera;
@@ -564,8 +564,8 @@ public class Drop extends ApplicationAdapter {
          camera.unproject(touchPos);
          bucket.x = touchPos.x - 64 / 2;
       }
-      if(Gdx.input.isKeyPressed(Keys.LEFT)) bucket.x -= 200 * Gdx.graphics.getDeltaTime();
-      if(Gdx.input.isKeyPressed(Keys.RIGHT)) bucket.x += 200 * Gdx.graphics.getDeltaTime();
+      if(Gdx.input.isKeyPressed(Input.Keys.LEFT)) bucket.x -= 200 * Gdx.graphics.getDeltaTime();
+      if(Gdx.input.isKeyPressed(Input.Keys.RIGHT)) bucket.x += 200 * Gdx.graphics.getDeltaTime();
 
       // make sure the bucket stays within the screen bounds
       if(bucket.x < 0) bucket.x = 0;


### PR DESCRIPTION
Follow up from a [report](https://discord.com/channels/348229412858101762/522048465736433664/1194522656813359134) on Discord:

The full source of the simple game differed from the steps shown above in the way the keys were referred to (`Input.Keys` by importing `Input` vs `Keys` by importing `Input.Keys`), this changes the full source so that the two are equivalent